### PR TITLE
remove random in report_miss

### DIFF
--- a/olo/cache.py
+++ b/olo/cache.py
@@ -53,10 +53,6 @@ class CacheWrapper(object):
         )
 
     def _report_miss(self, method_name, *args, **kwargs):
-
-        if random.random() > 0.02:
-            return
-
         level = kwargs.pop('olo_report_level', logging.WARNING)  # pragma: no cover pylint: disable=E
 
         msg = self._build_report_miss_msg(  # pragma: no cover


### PR DESCRIPTION
这个随机概率可以由开发者自己来定义吗？
比如说，开发环境是 100% ，线上环境是 5% .

此 pr 的的解决方案是，olo 完全不处理随机的逻辑，完全交由上游的 report 方法决定。
缺点是上游区分当前 report 是不是来自 report miss 比较麻烦。

是否有更好的解决方案？