### PR TITLE
add test for prefetch when get multi in different order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-          pip install pylint==2.12.2 pytest codecov
+          pip install pylint==2.12.2 pytest==7.1.2 pytest-subtests==0.14.1 codecov
       - name: Lint with pylint
         run: |
           pylint --rcfile=.pylintrc olo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-          pip install pylint==2.12.2 pytest==7.1.2 pytest-subtests==0.14.1 codecov
+          pip install pylint==2.12.2 pytest==7.4.4 pytest-subtests==0.14.1 codecov
       - name: Lint with pylint
         run: |
           pylint --rcfile=.pylintrc olo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-          pip install pylint==2.12.2 pytest==7.4.4 pytest-subtests==0.14.1 codecov
+          pip install pylint==2.12.2 pytest==7.1.2 pytest-subtests==0.13.1 codecov
       - name: Lint with pylint
         run: |
           pylint --rcfile=.pylintrc olo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
-          pip install pylint==2.12.2 pytest==7.1.2 codecov
+          pip install pylint==2.12.2 pytest codecov
       - name: Lint with pylint
         run: |
           pylint --rcfile=.pylintrc olo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     services:
       postgres:
         image: postgres

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -397,6 +397,28 @@ class TestDbField(TestCase):
                 self.assertEqual(db_get.call_count, 0)
                 self.assertEqual(db_get_multi.call_count, 4)
 
+    def test_prefetch_in_get_multi(self):
+        for i in xrange(1, 8):
+            Dummy.create(count=i, prop1=[i])
+
+        # get multi in different order
+        for ids in [
+            [1, 2, 3],
+            [3, 2, 1],
+            [2, 3, 1],
+        ]:
+            with patched_db_get as db_get:
+                with patched_db_get_multi as db_get_multi:
+                    print('ids:', ids)
+                    ds = Dummy.get_multi(ids)
+                    print('entities ids:', [d.id for d in ds[0]._olo_qs.entities])
+
+                    for d in ds:
+                        self.assertEqual(d.count, d.id)
+
+                    self.assertEqual(db_get.call_count, 0)
+                    self.assertEqual(db_get_multi.call_count, 3)
+
 
 class TestBatchField(TestCase):
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -410,15 +410,11 @@ class TestDbField(TestCase):
             with self.subTest(ids=ids):
                 with patched_db_get as db_get:
                     with patched_db_get_multi as db_get_multi:
-                        print('ids:', ids)
                         ds = Dummy.get_multi(ids)
-                        print('entities ids:', [d.id for d in ds[0]._olo_qs.entities])
 
                         for d in ds:
                             self.assertEqual(d.count, d.id)
 
-                        print('db get call count:', db_get.call_count)
-                        print('db get multi call count:', db_get_multi.call_count)
                         self.assertEqual(db_get.call_count, 0)
                         self.assertEqual(db_get_multi.call_count, 2)
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -407,19 +407,20 @@ class TestDbField(TestCase):
             [3, 2, 1],
             [2, 3, 1],
         ]:
-            with patched_db_get as db_get:
-                with patched_db_get_multi as db_get_multi:
-                    print('ids:', ids)
-                    ds = Dummy.get_multi(ids)
-                    print('entities ids:', [d.id for d in ds[0]._olo_qs.entities])
+            with self.subTest(ids=ids):
+                with patched_db_get as db_get:
+                    with patched_db_get_multi as db_get_multi:
+                        print('ids:', ids)
+                        ds = Dummy.get_multi(ids)
+                        print('entities ids:', [d.id for d in ds[0]._olo_qs.entities])
 
-                    for d in ds:
-                        self.assertEqual(d.count, d.id)
+                        for d in ds:
+                            self.assertEqual(d.count, d.id)
 
-                    print('db get call count:', db_get.call_count)
-                    print('db get multi call count:', db_get_multi.call_count)
-                    self.assertEqual(db_get.call_count, 0)
-                    self.assertEqual(db_get_multi.call_count, 2)
+                        print('db get call count:', db_get.call_count)
+                        print('db get multi call count:', db_get_multi.call_count)
+                        self.assertEqual(db_get.call_count, 0)
+                        self.assertEqual(db_get_multi.call_count, 2)
 
 
 class TestBatchField(TestCase):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -416,8 +416,10 @@ class TestDbField(TestCase):
                     for d in ds:
                         self.assertEqual(d.count, d.id)
 
+                    print('db get call count:', db_get.call_count)
+                    print('db get multi call count:', db_get_multi.call_count)
                     self.assertEqual(db_get.call_count, 0)
-                    self.assertEqual(db_get_multi.call_count, 3)
+                    self.assertEqual(db_get_multi.call_count, 2)
 
 
 class TestBatchField(TestCase):


### PR DESCRIPTION
bug 现象: 当以不同的顺序 `get_multi` 时, beansdb 的 qps 会不一样.