### PR TITLE
qaci: add Python 3.14 into unittest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
Python 3.14 was released at 2025-10-07.

cc @yetone